### PR TITLE
fix(cloudwatch logs): fix no logs showing up

### DIFF
--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_group" "lambda_log_group" {
-  name_prefix       = "/aws/lambda/commercetools_token_refresher"
+  name              = local.lambda_name
   retention_in_days = "30"
 }
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -3,6 +3,7 @@ data "aws_region" "current" {}
 
 locals {
   component_name  = "commercetools_token_refresher"
+  lambda_name     = "${var.site}-${local.component_name}"
   aws_account_id  = data.aws_caller_identity.current.account_id
   aws_region_name = data.aws_region.current.name
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,7 +22,7 @@ locals {
 }
 
 resource "aws_lambda_function" "commercetools_token_refresher" {
-  function_name = "${var.site}-${local.component_name}"
+  function_name = lambda_name
   role          = aws_iam_role.lambda.arn
   handler       = "handler.handle"
 
@@ -41,7 +41,7 @@ resource "aws_lambda_function" "commercetools_token_refresher" {
     variables = local.lambda_environment_variables
   }
 
-  # depends_on = [aws_cloudwatch_log_group.lambda_log_group]
+  depends_on = [aws_cloudwatch_log_group.lambda_log_group]
 }
 
 resource "aws_lambda_permission" "rotate_secrets_manager" {


### PR DESCRIPTION
Name must be `/aws/lambda/<function name>` according to https://docs.aws.amazon.com/lambda/latest/dg/monitoring-cloudwatchlogs.html 