### PR TITLE
fix: remove rotate scope permission condition

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - 'feature/**'
     tags:
       - '*'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 'feature/**'
     tags:
       - '*'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+version 0.3.1 (unreleased)
+--------------------------
+ - Remove too restrictive IAM policy condition which prevented scope-change trigger to rotate the token
+
+
 version 0.3.1 (2022-09-14)
 --------------------------
  - Add permission for scope-change lambda function to perform RotateSecret (#13)

--- a/terraform/events.tf
+++ b/terraform/events.tf
@@ -31,15 +31,6 @@ data "aws_iam_policy_document" "scope_change" {
     resources = [
       "arn:aws:secretsmanager:${local.aws_region_name}:${local.aws_account_id}:secret:*"
     ]
-
-    condition {
-      test     = "ArnEquals"
-      variable = "secretsmanager:RotateSecret"
-      values   = [
-        aws_lambda_function.commercetools_token_refresher.arn,
-        module.scope_change.lambda_function_arn,
-      ]
-    }
   }
   statement {
     effect = "Allow"


### PR DESCRIPTION
Condition didn't work and wasn't needed to satisfy any tfsec steps